### PR TITLE
[BUGFIX] Custom Doctrine functions must extend FunctionNode

### DIFF
--- a/lib/Fza/MysqlDoctrineLevenshteinFunction/DQL/LevenshteinFunction.php
+++ b/lib/Fza/MysqlDoctrineLevenshteinFunction/DQL/LevenshteinFunction.php
@@ -3,8 +3,9 @@
 namespace Fza\MysqlDoctrineLevenshteinFunction\DQL;
 
 use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 
-class LevenshteinFunction
+class LevenshteinFunction extends FunctionNode
 {
     public $firstStringExpression = null;
     public $secondStringExpression = null;

--- a/lib/Fza/MysqlDoctrineLevenshteinFunction/DQL/LevenshteinRatioFunction.php
+++ b/lib/Fza/MysqlDoctrineLevenshteinFunction/DQL/LevenshteinRatioFunction.php
@@ -3,8 +3,9 @@
 namespace Fza\MysqlDoctrineLevenshteinFunction\DQL;
 
 use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 
-class LevenshteinFunction
+class LevenshteinFunction extends FunctionNode
 {
     public $firstStringExpression = null;
     public $secondStringExpression = null;


### PR DESCRIPTION
This corrects the both Doctrine DQL functions to inherit
from \Doctrine\ORM\Query\AST\Functions\FunctionNode as described
at http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html#adding-your-own-functions-to-the-dql-language.

It won't work the other way, at least in recent versions
of Doctrine.
